### PR TITLE
Expose exporter.Handler and allow disabling default registry

### DIFF
--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -86,7 +86,7 @@ func TestConnect(t *testing.T) {
 			log.Fatal(err)
 		}
 
-		ts := httptest.NewServer(e.handler())
+		ts := httptest.NewServer(e.Handler())
 		defer ts.Close()
 
 		var wg sync.WaitGroup
@@ -122,7 +122,7 @@ func TestConnect(t *testing.T) {
 			log.Fatal(err)
 		}
 
-		ts := httptest.NewServer(e.handler())
+		ts := httptest.NewServer(e.Handler())
 		defer ts.Close()
 
 		var wg sync.WaitGroup


### PR DESCRIPTION
The Grafana Agent (https://github.com/grafana/agent) embeds mongodb_exporter as an integration, where it needs to be able to call into the exporter's HTTP handler for its all-in-one server. This endpoint also needs to only return metrics for the exporter itself and not from the global registry, which is populated by unrelated metrics.

This is a temporary PR for use in the Grafana Agent until percona/mongodb_exporter#356 is merged.